### PR TITLE
fix(eventignore removal)

### DIFF
--- a/lua/hydra/hint/window.lua
+++ b/lua/hydra/hint/window.lua
@@ -108,8 +108,6 @@ function HintAutoWindow:show()
    end
    if not self.win_config then self:_make_win_config() end
 
-   -- vim.o.eventignore = 'all' -- turn off autocommands
-
    local winid = api.nvim_open_win(self.buffer.id, false, self.win_config)
    ---@type hydra.api.Window
    local win = Window(winid)
@@ -119,8 +117,6 @@ function HintAutoWindow:show()
    win.wo.conceallevel = 3
    win.wo.foldenable = false
    win.wo.wrap = false
-
-   -- vim.o.eventignore = nil -- turn on autocommands
 
    autocmd('TabEnter', { group = augroup, callback = function()
       if self.win:is_valid() then

--- a/lua/hydra/hint/window.lua
+++ b/lua/hydra/hint/window.lua
@@ -108,7 +108,7 @@ function HintAutoWindow:show()
    end
    if not self.win_config then self:_make_win_config() end
 
-   vim.o.eventignore = 'all' -- turn off autocommands
+   -- vim.o.eventignore = 'all' -- turn off autocommands
 
    local winid = api.nvim_open_win(self.buffer.id, false, self.win_config)
    ---@type hydra.api.Window
@@ -120,7 +120,7 @@ function HintAutoWindow:show()
    win.wo.foldenable = false
    win.wo.wrap = false
 
-   vim.o.eventignore = nil -- turn on autocommands
+   -- vim.o.eventignore = nil -- turn on autocommands
 
    autocmd('TabEnter', { group = augroup, callback = function()
       if self.win:is_valid() then


### PR DESCRIPTION
Addresses #3 

For some reason, `vim.o.eventignore` was being used to disable all autocommands before the hydra window was created. This was causing some gnarly syntax issues down the road for literally all windows. Not really sure why that is the case but I have removed it. We may want to come back around to this later if this proves to be needed